### PR TITLE
Changed dependency on peakrdl to current release of 0.9.* (^0.9.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7.0"
 systemrdl-compiler = "^1.25.0"
-peakrdl = "^0.7.0"
+peakrdl = "^0.9.0"
 py-markdown-table = "^0.3.3"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Modified dependency on `peakrdl` to semver 0.9.\* which is the current `peakrdl` release.

Installed `peakrdl-markdown 0.1.5` with `peakrdl 0.9.0` and built markdown from .rdl source file.

Verified no reported error.

Verified markdown syntax in Typora.