### PR TITLE
use array index in identifiers

### DIFF
--- a/example/accelera_generic_example.md
+++ b/example/accelera_generic_example.md
@@ -21,30 +21,30 @@ how RDL can be utilized in various situations.</p>
 |0x0010|     myRegInst    |                  —                 |
 |0x0020|  spi4_pkt_count  |                  —                 |
 |0x0024|gige_pkt_count_reg|                  —                 |
-|0x0100|   fifo_port[8]   |                  —                 |
-|0x0110|   fifo_port[8]   |                  —                 |
-|0x0120|   fifo_port[8]   |                  —                 |
-|0x0130|   fifo_port[8]   |                  —                 |
-|0x0140|   fifo_port[8]   |                  —                 |
-|0x0150|   fifo_port[8]   |                  —                 |
-|0x0160|   fifo_port[8]   |                  —                 |
-|0x0170|   fifo_port[8]   |                  —                 |
-|0x1000|vc_pkt_count[8][2]|                  —                 |
-|0x1004|vc_pkt_count[8][2]|                  —                 |
-|0x1008|vc_pkt_count[8][2]|                  —                 |
-|0x100C|vc_pkt_count[8][2]|                  —                 |
-|0x1010|vc_pkt_count[8][2]|                  —                 |
-|0x1014|vc_pkt_count[8][2]|                  —                 |
-|0x1018|vc_pkt_count[8][2]|                  —                 |
-|0x101C|vc_pkt_count[8][2]|                  —                 |
-|0x1020|vc_pkt_count[8][2]|                  —                 |
-|0x1024|vc_pkt_count[8][2]|                  —                 |
-|0x1028|vc_pkt_count[8][2]|                  —                 |
-|0x102C|vc_pkt_count[8][2]|                  —                 |
-|0x1030|vc_pkt_count[8][2]|                  —                 |
-|0x1034|vc_pkt_count[8][2]|                  —                 |
-|0x1038|vc_pkt_count[8][2]|                  —                 |
-|0x103C|vc_pkt_count[8][2]|                  —                 |
+|0x0100|   fifo_port[0]   |                  —                 |
+|0x0110|   fifo_port[1]   |                  —                 |
+|0x0120|   fifo_port[2]   |                  —                 |
+|0x0130|   fifo_port[3]   |                  —                 |
+|0x0140|   fifo_port[4]   |                  —                 |
+|0x0150|   fifo_port[5]   |                  —                 |
+|0x0160|   fifo_port[6]   |                  —                 |
+|0x0170|   fifo_port[7]   |                  —                 |
+|0x1000|vc_pkt_count[0][0]|                  —                 |
+|0x1004|vc_pkt_count[0][1]|                  —                 |
+|0x1008|vc_pkt_count[1][0]|                  —                 |
+|0x100C|vc_pkt_count[1][1]|                  —                 |
+|0x1010|vc_pkt_count[2][0]|                  —                 |
+|0x1014|vc_pkt_count[2][1]|                  —                 |
+|0x1018|vc_pkt_count[3][0]|                  —                 |
+|0x101C|vc_pkt_count[3][1]|                  —                 |
+|0x1020|vc_pkt_count[4][0]|                  —                 |
+|0x1024|vc_pkt_count[4][1]|                  —                 |
+|0x1028|vc_pkt_count[5][0]|                  —                 |
+|0x102C|vc_pkt_count[5][1]|                  —                 |
+|0x1030|vc_pkt_count[6][0]|                  —                 |
+|0x1034|vc_pkt_count[6][1]|                  —                 |
+|0x1038|vc_pkt_count[7][0]|                  —                 |
+|0x103C|vc_pkt_count[7][1]|                  —                 |
 |0x2000|   empty_addrmap  |Empty addrmap with unsupported node.|
 
 ### chip_id_reg register
@@ -983,7 +983,7 @@ how RDL can be utilized in various situations.</p>
 
 |Offset|Identifier|Name|
 |------|----------|----|
-|  0x0 |  regs[1] |  — |
+|  0x0 |  regs[0] |  — |
 
 ### regs register
 

--- a/example/accelera_generic_example_depth_1.md
+++ b/example/accelera_generic_example_depth_1.md
@@ -21,28 +21,28 @@ how RDL can be utilized in various situations.</p>
 |0x0010|     myRegInst    |                  —                 |
 |0x0020|  spi4_pkt_count  |                  —                 |
 |0x0024|gige_pkt_count_reg|                  —                 |
-|0x0100|   fifo_port[8]   |                  —                 |
-|0x0110|   fifo_port[8]   |                  —                 |
-|0x0120|   fifo_port[8]   |                  —                 |
-|0x0130|   fifo_port[8]   |                  —                 |
-|0x0140|   fifo_port[8]   |                  —                 |
-|0x0150|   fifo_port[8]   |                  —                 |
-|0x0160|   fifo_port[8]   |                  —                 |
-|0x0170|   fifo_port[8]   |                  —                 |
-|0x1000|vc_pkt_count[8][2]|                  —                 |
-|0x1004|vc_pkt_count[8][2]|                  —                 |
-|0x1008|vc_pkt_count[8][2]|                  —                 |
-|0x100C|vc_pkt_count[8][2]|                  —                 |
-|0x1010|vc_pkt_count[8][2]|                  —                 |
-|0x1014|vc_pkt_count[8][2]|                  —                 |
-|0x1018|vc_pkt_count[8][2]|                  —                 |
-|0x101C|vc_pkt_count[8][2]|                  —                 |
-|0x1020|vc_pkt_count[8][2]|                  —                 |
-|0x1024|vc_pkt_count[8][2]|                  —                 |
-|0x1028|vc_pkt_count[8][2]|                  —                 |
-|0x102C|vc_pkt_count[8][2]|                  —                 |
-|0x1030|vc_pkt_count[8][2]|                  —                 |
-|0x1034|vc_pkt_count[8][2]|                  —                 |
-|0x1038|vc_pkt_count[8][2]|                  —                 |
-|0x103C|vc_pkt_count[8][2]|                  —                 |
+|0x0100|   fifo_port[0]   |                  —                 |
+|0x0110|   fifo_port[1]   |                  —                 |
+|0x0120|   fifo_port[2]   |                  —                 |
+|0x0130|   fifo_port[3]   |                  —                 |
+|0x0140|   fifo_port[4]   |                  —                 |
+|0x0150|   fifo_port[5]   |                  —                 |
+|0x0160|   fifo_port[6]   |                  —                 |
+|0x0170|   fifo_port[7]   |                  —                 |
+|0x1000|vc_pkt_count[0][0]|                  —                 |
+|0x1004|vc_pkt_count[0][1]|                  —                 |
+|0x1008|vc_pkt_count[1][0]|                  —                 |
+|0x100C|vc_pkt_count[1][1]|                  —                 |
+|0x1010|vc_pkt_count[2][0]|                  —                 |
+|0x1014|vc_pkt_count[2][1]|                  —                 |
+|0x1018|vc_pkt_count[3][0]|                  —                 |
+|0x101C|vc_pkt_count[3][1]|                  —                 |
+|0x1020|vc_pkt_count[4][0]|                  —                 |
+|0x1024|vc_pkt_count[4][1]|                  —                 |
+|0x1028|vc_pkt_count[5][0]|                  —                 |
+|0x102C|vc_pkt_count[5][1]|                  —                 |
+|0x1030|vc_pkt_count[6][0]|                  —                 |
+|0x1034|vc_pkt_count[6][1]|                  —                 |
+|0x1038|vc_pkt_count[7][0]|                  —                 |
+|0x103C|vc_pkt_count[7][1]|                  —                 |
 |0x2000|   empty_addrmap  |Empty addrmap with unsupported node.|

--- a/src/peakrdl_markdown/exporter.py
+++ b/src/peakrdl_markdown/exporter.py
@@ -137,8 +137,8 @@ class MarkdownExporter:  # pylint: disable=too-few-public-methods
         offset = node.address_offset
         identifier = node.inst_name
         if node.is_array:
-            assert node.array_dimensions is not None
-            identifier += "".join(f"[{dim}]" for dim in node.array_dimensions)
+            assert node.current_idx is not None
+            identifier += "".join(f"[{idx}]" for idx in node.current_idx)
         name = self._node_name_sanitized(node)
 
         table_row: "OrderedDict[str, Union[str, int]]" = OrderedDict()


### PR DESCRIPTION
This changes the identifier string for register arrays to use the array index rather than size of the array dimension. It addresses the basic issue raised in #5.